### PR TITLE
EC-305 Hotfix for review page stacked nav

### DIFF
--- a/Comments/ClientApp/src/components/ReviewPage/ReviewPage.js
+++ b/Comments/ClientApp/src/components/ReviewPage/ReviewPage.js
@@ -65,7 +65,8 @@ export class ReviewPage extends Component<PropsType> {
 					return {
 						label: consultationDocument.title,
 						url: `${this.props.location.pathname}?sourceURI=${encodeURIComponent(consultationDocument.sourceURI)}`,
-						current: this.getCurrentSourceURI() === consultationDocument.sourceURI
+						current: this.getCurrentSourceURI() === consultationDocument.sourceURI,
+						isReactRoute: true
 					};
 				}
 			);
@@ -156,7 +157,8 @@ export class ReviewPage extends Component<PropsType> {
 																	{
 																		label: title,
 																		url: this.props.location.pathname,
-																		current: this.getCurrentSourceURI() == null
+																		current: this.getCurrentSourceURI() == null,
+																		isReactRoute: true
 																	}
 																]
 															}


### PR DESCRIPTION
StackedNav component now requires "isReactRoute" flag to determine internal links, so added it to the nav elements on the review page. Will probably come back to this and set the default to be an internal link rather than needing to set explicitly.