### PR TITLE
EC-788 Adding array find polyfill for IE

### DIFF
--- a/Comments/ClientApp/src/index.js
+++ b/Comments/ClientApp/src/index.js
@@ -1,6 +1,7 @@
 import "core-js/es6/map";
 import "core-js/es6/set";
 import "core-js/fn/array/includes";
+import "core-js/fn/array/find";
 import "core-js/es6/regexp";
 import "raf/polyfill";
 import "classlist-polyfill";


### PR DESCRIPTION
https://nicedigital.atlassian.net/browse/EC-788

array.find not supported in any version of IE: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find